### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 An MCP (Model Context Protocol) server that enables AI applications to outsource tasks to various model providers through a unified interface.
 
+<a href="https://glama.ai/mcp/servers/@gwbischof/outsource-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gwbischof/outsource-mcp/badge" alt="Outsource MCP server" />
+</a>
+
 <img width="1154" alt="image" src="https://github.com/user-attachments/assets/cd364a7c-eae5-4c58-bc1f-fdeea6cb8434" />
 
 <img width="1103" alt="image" src="https://github.com/user-attachments/assets/55924981-83e9-4811-9f51-b049595b7505" />
 
 
-Compatible with any AI tool that supports the Model Context Protocol, including Claude Desktop, Cline, and other MCP-enabled applications.
-Built with [FastMCP](https://github.com/mcp/fastmcp) for the MCP server implementation and [Agno](https://github.com/agno-agi/agno) for AI agent capabilities.
+Compatible with any AI tool that supports the Model Context Protocol, including Claude Desktop, Cline, and other MCP-enabled applications. Built with [FastMCP](https://github.com/mcp/fastmcp) for the MCP server implementation and [Agno](https://github.com/agno-agi/agno) for AI agent capabilities.
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [Outsource MCP](https://glama.ai/mcp/servers/@gwbischof/outsource-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gwbischof/outsource-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gwbischof/outsource-mcp/badge" alt="Outsource MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.